### PR TITLE
Set default shell to bash

### DIFF
--- a/src/basecloj/.devcontainer/Dockerfile
+++ b/src/basecloj/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ARG USER_GID=$USER_UID
     
 # Create the user
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME -s /bin/bash \
     #
     # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
     && apt-get update \


### PR DESCRIPTION
Fixes https://github.com/devcontainers-extra/features/issues/101 and allows other features that assume a bash default shell to install without an error, e.g. https://github.com/devcontainers/features/tree/main/src/node.

Tested with `basecloj`, I was able to successfully install both of the above features.

I think `scicloj` will probably also need the same fix, but not including in this PR as I didn't test that yet.