### PR TITLE
Python feature forced upgrade in the Scicloj template's devcontainer.json

### DIFF
--- a/src/scicloj/.devcontainer/devcontainer.json
+++ b/src/scicloj/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
 			"ppas": "ppa:ubuntuhandbook1/emacs",
 			"packages": "r-base-dev,emacs,rlwrap,fonts-hack"
 		},
-		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "latest"
+		},
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {},
 		"ghcr.io/rocker-org/devcontainer-features/r-apt:0": {},
 		"ghcr.io/rocker-org/devcontainer-features/rstudio-server": {},


### PR DESCRIPTION
Poetry requires a current version of Python.
The Python feature defaults to "os-provided", not to "latest". The OS-provided value is currently (Python) 3.10, resulting in an incompatibility with Poetry.  This is contrary to the convention, mentioned at thttps://github.com/devcontainers/features/blob/main/README.md. To verify this is the case, please see:
https://github.com/devcontainers/features/blob/main/src/python/devcontainer-feature.json